### PR TITLE
Correct architectures value in library.properties

### DIFF
--- a/library.properties
+++ b/library.properties
@@ -6,4 +6,4 @@ sentence=Triad Semiconductor library for the TS8000 Ultrasonic to Digital Conver
 paragraph=The TS8000 must be configured and calibrated at power-up.  This library provides example code to perform those functions.
 category=Sensors
 url=https://github.com/TriadSemi/TS8000
-architectures=SAMD21
+architectures=samd


### PR DESCRIPTION
The previous `architectures` value caused the Arduino IDE to display a warning when the library is compiled:
```
WARNING: library TS8000 claims to run on (SAMD21) architecture(s) and may be incompatible with your current board which runs on (samd) architecture(s).
```
The previous `architectures` value caused the library's examples to be placed under the **File > Examples > INCOMPATIBLE** menu.